### PR TITLE
add application/json header

### DIFF
--- a/html/ajax_table.php
+++ b/html/ajax_table.php
@@ -36,6 +36,7 @@ $response     = array();
 
 if (isset($id)) {
     if (file_exists("includes/table/$id.inc.php")) {
+        header('Content-type: application/json');
         include_once "includes/table/$id.inc.php";
     }
 }


### PR DESCRIPTION
This fixes a problem where a reverse proxy is being used in conjunction with apache directive 'ProxyHTMLEnable On'.  If the application/json header is not set, it is automatically encapsulated in html paragraph tags, which breaks the javascript that called the URL.