### PR TITLE
skip authentication if not configured

### DIFF
--- a/html/graph.php
+++ b/html/graph.php
@@ -40,8 +40,9 @@ require_once '../includes/dbFacile.php';
 require_once '../includes/rewrites.php';
 require_once 'includes/functions.inc.php';
 require_once '../includes/rrdtool.inc.php';
-require_once 'includes/authenticate.inc.php';
-
+if($config['allow_unauth_graphs'] == 0) {
+  require_once 'includes/authenticate.inc.php';
+}
 require 'includes/graphs/graph.inc.php';
 
 $console_color = new Console_Color2();


### PR DESCRIPTION
$config['allow_unauth_graphs'] can be set to 1 which is intended to skip authentication.  Skipping the inclusion of authentication.inc.php saves major overhead in rendering graphs.